### PR TITLE
Add support for HTTPS (including self-signed certificates)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # serverspec-extended-types, changelog
 
+## HEAD
+
+* Add `protocol` (http|https) and `bypass_ssl_verify` parameters for http_get.
+
 ## 0.0.3 2015-03-23 Jason Antman <jason@jasonantman.com>
 
 * Add ``json`` matcher for http_get type.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The http_get type performs an HTTP GET from the local (rspec runner) system, aga
 the IP address that serverspec is running against (``ENV[TARGET_HOST]``), with a
 specified ``Host`` header value. The request is wrapped in a configurable-length timeout.
 
-    describe http_get(port, host_header, path, timeout_sec=10)
+    describe http_get(port, host_header, path, timeout_sec=10, protocol='http', bypass_ssl_verify=false)
       # matchers here
 	end
 
@@ -123,6 +123,8 @@ state variables for later use by the various matchers.
 * __host_header__ - the ``Host`` header value to provide in the request
 * __path__ - the path to request from the server
 * __timeout_sec__ - timeout in seconds before canceling the request (Int; default 10)
+* __protocol__ - protocol to be used (default to `http`,  can be `http`)
+* __bypass_ssl_verify__ - bypass SSL verification (default to `false` to keep good security. Set it to `true` for self-signed certificates only!)
 
 #### Matchers
 


### PR DESCRIPTION
In this PR, `http_get` is extended to allow targeting SSL-enabled servers. There is an extra option to bypass SSL verification, to be used for self-signed certificates (often used with Vagrant for instance).

Example:

```ruby
describe http_get(443, 'vagrant-server.acme.com', '/', 1, 'https', true) do
  # SNIP
end
```

Ultimately I think using named parameters (keyword arguments) will be better, but I decided not to do it yet, to preserve compatibility.