### PR TITLE
Http redirects testing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # serverspec-extended-types, changelog
 
+## 0.1.1 2017-07-28 ojizero <z.acnts.816@protonmail.ch>
+
+* Add `redirected_to` and `redirected` matchers for http_get type.
+
 ## 0.1.0 2017-05-15 Jason Antman <jason@jasonantman.com>
 
 * Add `protocol` (http|https) and `bypass_ssl_verify` parameters for http_get.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Returns the String body content of the HTTP response.
 
     describe http_get(80, 'myhostname', '/') do
       its(:body) { should match /<html>/ }
-	end
+    end
 
 ##### headers
 
@@ -167,7 +167,27 @@ True if the request timed out, false otherwise.
 
     describe http_get(80, 'myhostname', '/') do
       it { should_not be_timed_out }
-	end
+    end
+
+##### redirected?
+
+True if the request was redirected, false otherwise.
+
+    describe http_get(80, 'myhostname', '/') do
+      it { should be_redirected }
+    end
+
+##### redirected_to?
+
+True if the request was redirected to the specified location, false otherwise.
+
+    describe http_get(80, 'myhostname', '/') do
+      it { should be_redirected_to 'https://myhostname/newpath' }
+    end
+
+    describe http_get(80, 'myhostname', '/') do
+      it { should be_redirected_to 'http://mynewhost/' }
+    end
 
 ### virtualenv
 

--- a/lib/serverspec_extended_types/version.rb
+++ b/lib/serverspec_extended_types/version.rb
@@ -1,3 +1,3 @@
 module ServerspecExtendedTypes
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/types/bitlbee_spec.rb
+++ b/spec/types/bitlbee_spec.rb
@@ -96,9 +96,9 @@ describe 'Serverspec::Type::Bitlbee' do
       expect(sslsock_dbl).to receive(:puts).ordered.with("QUIT :\"outta here\"\n")
       expect(sslsock_dbl).to receive(:close).ordered
       expect(OpenSSL::SSL::SSLSocket).to receive(:new).with(sock_dbl, sslctx_dbl).and_return(sslsock_dbl)
-      #expect_any_instance_of(Serverspec::Type::Bitlbee).to receive(:communicate)
+      # expect_any_instance_of(Serverspec::Type::Bitlbee).to receive(:communicate)
       x = bitlbee(1, 'foo', 'bar')
-      x.stub(:communicate) do
+      allow(x).to receive(:communicate) do
         x.instance_variable_get(:@socket).puts("communicate")
       end
       x.connect_ssl
@@ -114,7 +114,7 @@ describe 'Serverspec::Type::Bitlbee' do
       expect(sock_dbl).to receive(:puts).ordered.with("QUIT :\"outta here\"\n")
       expect(sock_dbl).to receive(:close).ordered
       x = bitlbee(1, 'foo', 'bar')
-      x.stub(:communicate) do
+      allow(x).to receive(:communicate) do
         x.instance_variable_get(:@socket).puts("communicate")
       end
       x.connect

--- a/spec/types/http_get_spec.rb
+++ b/spec/types/http_get_spec.rb
@@ -148,8 +148,8 @@ describe 'http_get()' do
       expect(x.instance_variable_get(:@redirect_path)).to be nil
 
       # test exposed API
-      x.should_not be_redirected
-      x.should_not be_redirected_to 'https://myhost:1/mynewpath'
+      expect(x).to_not be_redirected
+      expect(x).to_not be_redirected_to 'https://myhost:1/mynewpath'
     end
     it 'supports redirects' do
       stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'myhost'))
@@ -174,8 +174,8 @@ describe 'http_get()' do
       expect(x.instance_variable_get(:@redirect_path)).to eq redirect_location
 
       # test exposed API
-      x.should be_redirected
-      x.should be_redirected_to redirect_location
+      expect(x).to be_redirected
+      expect(x).to be_redirected_to redirect_location
     end
   end
 end

--- a/spec/types/http_get_spec.rb
+++ b/spec/types/http_get_spec.rb
@@ -28,6 +28,8 @@ describe 'http_get()' do
       expect(x.instance_variable_get(:@response_json)).to be nil
       expect(x.instance_variable_get(:@protocol)).to eq 'http'
       expect(x.instance_variable_get(:@bypass_ssl_verify)).to eq false
+      expect(x.instance_variable_get(:@redirects)).to eq false
+      expect(x.instance_variable_get(:@redirect_path)).to be nil
     end
     it 'calls getpage' do
       expect_any_instance_of(Serverspec::Type::Http_Get).to receive(:getpage).once
@@ -124,6 +126,56 @@ describe 'http_get()' do
       expect(x.headers).to eq expected_headers
       expected_json = {"foo" => "bar", "baz" => {"blam" => "blarg"}}
       expect(x.json).to eq expected_json
+    end
+    it 'without redirects' do
+      stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'myhost'))
+
+      headers = double('header')
+      conn = double('conn', headers: headers)
+
+      expect(headers).to receive(:[]=).with(:user_agent, %r"Serverspec::Type::Http_Get/\d+\.\d+\.\d+ \(https://github.com/jantman/serverspec-extended-types\)")
+      expect(headers).to receive(:[]=).with(:Host, 'hostheader')
+
+      response = double('resp', status: 200, body: 'OK', headers: ({}))
+
+      expect(conn).to receive(:get).with('mypath').and_return(response)
+
+      expect(Faraday).to receive(:new).with('http://myhost:1/').and_return(conn)
+      x = http_get(1, 'hostheader', 'mypath')
+
+      # test internal parameters
+      expect(x.instance_variable_get(:@redirects)).to eq false
+      expect(x.instance_variable_get(:@redirect_path)).to be nil
+
+      # test exposed API
+      x.should_not be_redirected
+      x.should_not be_redirected_to 'https://myhost:1/mynewpath'
+    end
+    it 'supports redirects' do
+      stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'myhost'))
+
+      headers = double('header')
+      conn = double('conn', headers: headers)
+
+      expect(headers).to receive(:[]=).with(:user_agent, %r"Serverspec::Type::Http_Get/\d+\.\d+\.\d+ \(https://github.com/jantman/serverspec-extended-types\)")
+      expect(headers).to receive(:[]=).with(:Host, 'hostheader')
+
+      redirect_location = 'https://myhost:1/mynewpath'
+      response = double('resp', status: 301, body: 'OK', headers: {'location' => redirect_location})
+
+      expect(conn).to receive(:get).with('mypath').and_return(response)
+
+      expect(Faraday).to receive(:new).with('http://myhost:1/').and_return(conn)
+      x = http_get(1, 'hostheader', 'mypath')
+
+      # test internal parameters
+      expect(x.instance_variable_get(:@redirects)).to eq true
+      expect(x.instance_variable_get(:@redirect_path)).to_not be nil
+      expect(x.instance_variable_get(:@redirect_path)).to eq redirect_location
+
+      # test exposed API
+      x.should be_redirected
+      x.should be_redirected_to redirect_location
     end
   end
 end


### PR DESCRIPTION
Adds ability to test whether HTTP get receives redirects, and if said redirects are correct.