### PR TITLE
bump TravisCI rvm from 2.0.0 to 2.5.3 to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bundle exec rake test
 notifications:
   email: true
 rvm:
-  - 2.0.0
+  - 2.5.3
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/serverspec-extended-types.gemspec
+++ b/serverspec-extended-types.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', '>= 3.0'
   spec.add_dependency 'faraday'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codecov'


### PR DESCRIPTION
This fixes the TravisCI tests that have been failing for... ages...